### PR TITLE
dcraw: Small fix for different model tag (RP_ov6457) seen in JPEG data

### DIFF
--- a/dcraw/dcraw.c
+++ b/dcraw/dcraw.c
@@ -7844,7 +7844,8 @@ void CLASS identify()
             height = header.height;
           }
         }
-      } else if (!strncmp(model, "RP_OV",5)) {
+      } else if (!(strncmp(model, "RP_OV",5) &&
+                   strncmp(model, "RP_ov",5))) {
         if(!fseek (ifp, -6404096, SEEK_END) &&
 	         fread (head, 1, 32, ifp) && !strncmp(head,"BRCM", 4)) {
           strcpy (make, "OmniVision");


### PR DESCRIPTION
This is to address the image
https://hodapple.com/files/dcraw_test/arducam_201609.jpg which
existing dcraw versions (both revision 1.477 and the version in this
repo) fail to handle properly, as noted in
https://www.raspberrypi.org/forums/viewtopic.php?p=1043088#p1043088.
